### PR TITLE
fix bbox query format

### DIFF
--- a/pydggsapi/routers/dggs_api.py
+++ b/pydggsapi/routers/dggs_api.py
@@ -4,7 +4,7 @@
 # in the main api.py under /dggs-api/v1-pre
 
 from fastapi import APIRouter, HTTPException, Depends, Request, Path
-from typing import Optional, Dict, Union
+from typing import Annotated, Optional, Dict, Union
 
 from pydggsapi.schemas.ogc_dggs.dggrs_list import DggrsListResponse
 from pydggsapi.schemas.ogc_dggs.dggrs_descrption import DggrsDescriptionRequest, DggrsDescription
@@ -33,6 +33,7 @@ import logging
 import copy
 import pyproj
 import importlib
+import traceback
 from shapely.geometry import box
 from shapely.ops import transform
 
@@ -323,7 +324,7 @@ async def dggrs_zone_info(req: Request, zoneinfoReq: ZoneInfoRequest = Depends()
 
 @router.get("/dggs/{dggrsId}/zones", response_model=Union[ZonesResponse, ZonesGeoJson], tags=['ogc-dggs-api'])
 @router.get("/collections/{collectionId}/dggs/{dggrsId}/zones", response_model=Union[ZonesResponse, ZonesGeoJson], tags=['ogc-dggs-api'])
-async def list_dggrs_zones(req: Request, zonesReq: ZonesRequest = Depends(),
+async def list_dggrs_zones(req: Request, zonesReq: Annotated[ZonesRequest, Depends()],
                            dggrs_description: DggrsDescription = Depends(_get_dggrs_description),
                            dggrs_provider: AbstractDGGRSProvider = Depends(_get_dggrs_provider),
                            collection: Dict[str, Collection] = Depends(_get_collection),
@@ -419,6 +420,3 @@ async def dggrs_zones_data(req: Request, zonedataReq: ZonesDataRequest = Depends
     except Exception as e:
         logger.error(f'{__name__} data_retrieval failed: {e}')
         raise HTTPException(status_code=400, detail=f'{__name__} data_retrieval failed: {e}')
-
-
-

--- a/pydggsapi/schemas/ogc_dggs/dggrs_zones.py
+++ b/pydggsapi/schemas/ogc_dggs/dggrs_zones.py
@@ -11,7 +11,7 @@ zone_query_support_returntype = ['application/json', 'application/geo+json']
 zone_query_support_geometry = ['zone-centroid', 'zone-region']
 
 
-def bbox_converter(bbox: Optional[str]) -> Optional[List[float]]:
+def bbox_converter(bbox: Optional[str] = None) -> Optional[List[float]]:
     if not bbox:
         return None
     if isinstance(bbox, str):

--- a/pydggsapi/schemas/ogc_dggs/dggrs_zones.py
+++ b/pydggsapi/schemas/ogc_dggs/dggrs_zones.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 from pydggsapi.schemas.ogc_dggs.common_ogc_dggs_api import CrsModel, Feature
 from pydggsapi.schemas.ogc_dggs.dggrs_descrption import DggrsDescriptionRequest
-from typing import List, Optional, Union
-from fastapi import Query
+from typing import Annotated, List, Optional, Union, Tuple
+from fastapi import Depends
 from fastapi.exceptions import HTTPException
 
-from pydantic import BaseModel, conint, Field, model_validator
+from pydantic import BaseModel, conint, model_validator
 
 zone_query_support_returntype = ['application/json', 'application/geo+json']
 zone_query_support_geometry = ['zone-centroid', 'zone-region']
+
+
+def bbox_converter(bbox: Optional[str]) -> Optional[List[float]]:
+    if not bbox:
+        return None
+    if isinstance(bbox, str):
+        bbox = bbox.split(",")
+    return [float(i) for i in bbox]
 
 
 class ZonesRequest(DggrsDescriptionRequest):
@@ -17,7 +25,10 @@ class ZonesRequest(DggrsDescriptionRequest):
     parent_zone: Optional[Union[int, str]] = None
     limit: Optional[int] = None
     bbox_crs: Optional[str] = None
-    bbox: Optional[List[float]] = Field(Query(None))
+    bbox: Annotated[
+        Optional[Union[List[float], Tuple[float, float, float, float]]],
+        Depends(bbox_converter)
+    ] = None
     geometry: Optional[str] = None
 
     @model_validator(mode="after")


### PR DESCRIPTION
Fix the resolution of the query to use the expected `/dggs-api/v1-pre/dggs/h3/zones?bbox=-98.0,50.25,-96.5,48` instead of the current `...?bbox=-98.0&bbox=50.25&bbox=-96.5&bbox=48` 

<img width="745" height="405" alt="{D5CC7AB2-4402-4AE8-A511-9C1DC10E6EB5}" src="https://github.com/user-attachments/assets/201ae785-7cbe-486d-a00d-8069037bb95a" />
