### PR TITLE
remove UNNEST unsupported by DuckDB

### DIFF
--- a/pydggsapi/dependencies/collections_providers/parquet_collection_provider.py
+++ b/pydggsapi/dependencies/collections_providers/parquet_collection_provider.py
@@ -43,7 +43,7 @@ class ParquetCollectionProvider(AbstractCollectionProvider):
             return result
         cols = f"{','.join(datasource.data_cols)},{datasource.id_col}" if ("*" not in datasource.data_cols) else "*"
         sql = f"""select {cols} from read_parquet('{datasource.filepath}')
-                  where {datasource.id_col} in (SELECT UNNEST(?))"""
+                  where {datasource.id_col} in (SELECT ?)"""
         try:
             result_df = datasource.conn.sql(sql, params=[zoneIds]).df()
         except Exception as e:


### PR DESCRIPTION
Testing out the parquet provider. 
Seems to work well, but I encountered a small issue when passing down the zoneID.

After the fix, my same file resolves the zoneID correctly.

<img width="759" height="949" alt="{65C39C13-FFFC-43E9-84EB-9B6B898C262C}" src="https://github.com/user-attachments/assets/e650ef39-07c9-408a-af37-d705834cfda8" />
