### PR TITLE
pre-resolve float-like string before int

### DIFF
--- a/pydggsapi/models/ogc_dggs/data_retrieval.py
+++ b/pydggsapi/models/ogc_dggs/data_retrieval.py
@@ -62,7 +62,8 @@ def query_zone_data(zoneId: str | int, zone_levels: List[int], dggrs_description
                 tmp = pd.DataFrame(np.concatenate([id_, collection_result.data], axis=-1),
                                    columns=['zoneId'] + list(cols_name.keys())).set_index('zoneId')
                 master = master.join(tmp)
-                master = master.astype(cols_name)
+                pre_numeric_cols = {c: str(dtype).replace("int", "float") for c, dtype in cols_name.items()}
+                master = master.astype(pre_numeric_cols).astype(cols_name)
                 if (convert):
                     master.reset_index(inplace=True)
                     tmp_geo = master.groupby('vid')['geometry'].last()
@@ -132,16 +133,3 @@ def query_zone_data(zoneId: str | int, zone_levels: List[int], dggrs_description
     return_ = {'dggrs': link, 'zoneId': str(zoneId), 'depths': zone_levels if (exclude is False) else zone_levels[1:],
                'properties': properties, 'values': values}
     return ZonesDataDggsJsonResponse(**return_)
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
When converting `.astype()` with a combination of `float64` and `int64` columns, the `int64` data can fail to convert because of previous conversions (from `CollectionProvider.get_data()`) that could have cast the "int" into an object-like string with floating point value [eg: `9` (int) becomes `"9.0"` (float-like str)].

<img width="1748" height="631" alt="image" src="https://github.com/user-attachments/assets/e4b85a6d-166b-4f0e-9989-7a18024086d1" />

This change does a pre-cast to float of numeric values, and then applies the int cast as appropriate. Since float can handle either int/float/string-like, it succeed the conversion, before being down-casted to int. 