### PR TITLE
fix invalid `[ogc-rel:dggrs-definition]` link relation

### DIFF
--- a/pydggsapi/dependencies/api/dggrs.py
+++ b/pydggsapi/dependencies/api/dggrs.py
@@ -66,7 +66,11 @@ def get_dggrs_descriptions() -> Dict[str, DggrsDescription]:
     for dggrs in dggrs_indexes:
         dggrsid, dggrs_config = dggrs.popitem()
         self_link = Link(**{'href': '', 'rel': 'self', 'title': 'DGGRS description link'})
-        dggrs_model_link = Link(**{'href': dggrs_config['definition_link'], 'rel': 'ogc-rel:dggrs-definition', 'title': 'DGGRS definition'})
+        dggrs_model_link = Link(**{
+            'href': dggrs_config['definition_link'],
+            'rel': '[ogc-rel:dggrs-definition]',
+            'title': 'DGGRS definition',
+        })
         dggrs_config['id'] = dggrsid
         dggrs_config['maxRefinementLevel'] = max_dggrs.get(dggrsid, 32)
         dggrs_config['links'] = [self_link, dggrs_model_link]

--- a/pydggsapi/models/ogc_dggs/data_retrieval.py
+++ b/pydggsapi/models/ogc_dggs/data_retrieval.py
@@ -129,7 +129,10 @@ def query_zone_data(zoneId: str | int, zone_levels: List[int], dggrs_description
         return FileResponse(tmpfile[1], headers={'content-type': 'application/zarr+zip'})
     if (returntype == 'application/geo+json'):
         return ZonesDataGeoJson(**{'type': 'FeatureCollection', 'features': features})
-    link = [k.href for k in dggrs_description.links if (k.rel == 'ogc-rel:dggrs-definition')][0]
+    link = [
+        k.href for k in dggrs_description.links
+        if k.rel in ('[ogc-rel:dggrs-definition]', 'https://www.opengis.net/def/rel/ogc/1.0/dggrs-definition')
+    ][0]
     return_ = {'dggrs': link, 'zoneId': str(zoneId), 'depths': zone_levels if (exclude is False) else zone_levels[1:],
                'properties': properties, 'values': values}
     return ZonesDataDggsJsonResponse(**return_)

--- a/pydggsapi/schemas/ogc_dggs/dggrs_descrption.py
+++ b/pydggsapi/schemas/ogc_dggs/dggrs_descrption.py
@@ -17,7 +17,7 @@ class DggrsDescription(BaseModel):
     )
     title: str = Field(
         ...,
-        description='Title of this Discrete Global Grid Rfeference System, intended for displaying to a human',
+        description='Title of this Discrete Global Grid Reference System, intended for displaying to a human',
     )
     description: str = Field(
         ...,


### PR DESCRIPTION
Plain `{"rel": "ogc-rel:dggrs-definition"}` links were used, but this is invalid. The CURIE form `[ogc-rel:dggrs-definition]` is expected, which maps to the long from [`https://www.opengis.net/def/rel/ogc/1.0/dggrs-definition`](https://www.opengis.net/def/rel/ogc/1.0/dggrs-definition).