### PR TITLE
fix extent temporal interval

### DIFF
--- a/pydggsapi/schemas/ogc_collections/extent.py
+++ b/pydggsapi/schemas/ogc_collections/extent.py
@@ -7,10 +7,10 @@ from fastapi.exceptions import HTTPException
 class Spatial(BaseModel):
     bbox: List[List[float]]
     storageCrsBbox: Optional[List[float]] = None
-    crs: Optional[List[str]] = Field(
-        ['http://www.opengis.net/def/crs/OGC/1.3/CRS84'],
+    crs: Optional[str] = Field(
+        'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
         description='the list of coordinate reference systems supported by the API; the first item is the default coordinate reference system',
-        example=[
+        examples=[
             'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
             'http://www.opengis.net/def/crs/EPSG/0/4326',
         ],
@@ -31,13 +31,13 @@ class Temporal(BaseModel):
         Tuple[Optional[str], Optional[str]],
         min_length=1,
     )] = None
-    crs: Optional[List[str]] = Field(
-        [''],
+    trs: Optional[str] = Field(
+        'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
         description="""Coordinate reference system of the coordinates in the temporal extent
                          (property interval). The default reference system is the Gregorian calendar.
                          For data for which the Gregorian calendar is not suitable, such as geological time scale,
                          another temporal reference system may be used""",
-        example=[
+        examples=[
             'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
         ],
     )


### PR DESCRIPTION
## Fixes
- Same fix as spatial, where nested arrays are needed for `interval`.
- Adjust the `crs`/`trs` properties.

For `interval`, I leverage the `tuple` to enforce the 2 datetime values, while `conlist` enforces the minimal single interval. 

Based on the schema: 
https://github.com/opengeospatial/ogcapi-common/blob/beb17aa8fc009bb5d5b3c9114913a5542be173fb/collections/openapi/schemas/common-geodata/extent.yaml#L141-L178

## Example 
<img width="531" height="367" alt="{DD8D33BB-96A2-45C5-B846-E91CC7E1EF0F}" src="https://github.com/user-attachments/assets/a2dd681b-eea7-4c10-ada1-84a867116637" />

