### PR TITLE
add CI docker git tag push condition

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
 
 permissions:
   contents: read


### PR DESCRIPTION
Add the condition that allows to trigger a docker build/publish on a given git tag.

The CI was already defined to handle this case, but was not triggered due to the event conditions.