### PR TITLE
avoid `../dggs/{id}` expanding links indefinitely

### DIFF
--- a/pydggsapi/routers/dggs_api.py
+++ b/pydggsapi/routers/dggs_api.py
@@ -361,7 +361,7 @@ async def dggrs_description(
     collection: Dict[str, Collection] = Depends(_get_collection),
     dggrs_provider=Depends(_get_dggrs_provider)
 ) -> Union[DggrsDescription, Response]:
-
+    dggrs_description = dggrs_description.model_copy(deep=True)
     current_url = str(req.url)
     if (dggrs_req.collectionId is not None):
         collection = collection[dggrs_req.collectionId]


### PR DESCRIPTION
When requesting either `/dggs/{dggrsID}` or `/collections/{id}/dggs/{dggrsID}` multiple times in a row, or for the corresponding `dggrsID`, the `links` section would indefinitely expand with extra `"[ogc-rel:dggrs-zone-query]"` links due to how they are being inserted by the `query_dggrs_definition` function.

To avoid any other similar problems of by-reference updates, directly copy the entire structure at the start. 