### PR TITLE
Supprot GZIP compression responses

### DIFF
--- a/pydggsapi/api.py
+++ b/pydggsapi/api.py
@@ -1,6 +1,7 @@
 # Test for sub-folder changes
 from fastapi import FastAPI, Depends, Path, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.openapi.utils import get_openapi
 from dotenv import load_dotenv
 
@@ -52,6 +53,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+if os.getenv('GZIP_ENABLED', 'true').lower() == 'true':
+    app.add_middleware(
+        GZipMiddleware,
+        compresslevel=os.getenv('GZIP_COMPRESS_LEVEL', 5),
+        minimum_size=os.getenv('GZIP_MINIMUM_SIZE', 500),
+    )
 
 dggs_prefix = os.environ.get('DGGS_PREFIX', '/dggs-api/v1-pre')
 tiles_prefix = os.environ.get('TILES_PREFIX', '/tiles-api')


### PR DESCRIPTION
# Changes

Add GZIP middleware to allow `Accept-Encoding: gzip` consideration.

As observed below, the resulting response adapts adequately to acceptable compression in the request, and applies it with notable `Content-Length` reduction [173063 → 21440 DGGS-JSON → 10737 DGGS-(UB)JSON].

The `GZIP_ENABLED`, `GZIP_COMPRESS_LEVEL` and `GZIP_MINIMUM_SIZE` env variables are available for quick/easy customization on the deployed service.

## Before  (or using env `GZIP_ENABLED=false`)

<img width="651" height="331" alt="{C5F189F5-9369-47CF-8035-241D2C8B5646}" src="https://github.com/user-attachments/assets/c8cadec7-f75c-4194-9eb7-8e6c3d38c1f8" />


## After

With `Accept-Encoding: gzip`:

<img width="645" height="368" alt="{A22BF575-706E-402F-B3BE-75C306225D19}" src="https://github.com/user-attachments/assets/68df134d-7f44-4552-9b89-c003cecfab75" />

With `Accept-Encoding: gzip` + DGGS-(UB)JSON format

<img width="645" height="368" alt="{01BA5E6D-EF0A-4595-BD4A-C93697C492DA}" src="https://github.com/user-attachments/assets/fef93fe9-270b-424d-b69f-fdfd20fe6e59" />

And without `Accept-Encoding: gzip`, still behaves like before:

<img width="1192" height="404" alt="{B8579E21-0416-4F40-8C52-4343A4A4D105}" src="https://github.com/user-attachments/assets/520a68a4-2d02-42da-9881-088116c62da9" />

