### PR TITLE
Multiple improvements for DGGS link reporting

### DIFF
--- a/pydggsapi/dependencies/api/dggrs.py
+++ b/pydggsapi/dependencies/api/dggrs.py
@@ -86,13 +86,20 @@ def get_dggrs_descriptions() -> Dict[str, DggrsDescription]:
             max_dggrs[cp.dggrsId] = cp.max_refinement_level
     for dggrs in dggrs_indexes:
         dggrsid, dggrs_config = dggrs.popitem()
-        self_link = Link(**{'href': '', 'rel': 'self', 'title': 'DGGRS description link'})
-        dggrs_model_link = Link(**{
-            'href': dggrs_config['definition_link'],
-            'rel': '[ogc-rel:dggrs-definition]',
-            'title': 'DGGRS definition',
-        })
+        dggrs_def = dggrs_config['definition_link'] or f'[ogc-dggrs:{dggrsid}]'
+        self_link = Link(
+            href='',
+            type='application/json',
+            rel='self',
+            title='DGGRS description link',
+        )
+        dggrs_model_link = Link(
+            href=dggrs_def,
+            rel='[ogc-rel:dggrs-definition]',
+            title='DGGRS definition',
+        )
         dggrs_config['id'] = dggrsid
+        dggrs_config['uri'] = dggrs_def
         dggrs_config['maxRefinementLevel'] = max_dggrs.get(dggrsid, 32)
         dggrs_config['links'] = [self_link, dggrs_model_link]
         del dggrs_config['definition_link']

--- a/pydggsapi/schemas/ogc_dggs/common_ogc_dggs_api.py
+++ b/pydggsapi/schemas/ogc_dggs/common_ogc_dggs_api.py
@@ -15,7 +15,7 @@ class LinkBase(CommonBaseModel):
         description='The type or semantics of the relation.',
         examples=['alternate'],
     )
-    type: Optional[str] = Field(
+    type: Annotated[Optional[str], OmitIfNone] = Field(
         None,
         description='A hint indicating what the media type of the result of dereferencing the link should be.',
         examples=['application/geo+json'],
@@ -64,7 +64,7 @@ class LinkTemplate(LinkBase):
         ),
         examples=['http://data.example.com/buildings/{featureId}'],
     )
-    varBase: Optional[str] = Field(
+    varBase: Annotated[Optional[str], OmitIfNone] = Field(
         None,
         description='A base path to retrieve semantic information about the variables used in URL template.',
         examples=['/ogcapi/vars/'],

--- a/pydggsapi/schemas/ogc_dggs/dggrs_descrption.py
+++ b/pydggsapi/schemas/ogc_dggs/dggrs_descrption.py
@@ -27,8 +27,8 @@ class DggrsDescription(BaseModel):
         None,
         description='Unordered list of one or more commonly used or formalized word(s) or phrase(s) used to describe this Discrete Global Grid Reference System',
     )
-    uri: Optional[AnyUrl] = Field(
-        None,
+    uri: Union[AnyUrl, str] = Field(  # can be a URI or a compact URI (CURIE)
+        ...,
         description='Identifier for this Discrete Global Grid Reference System registered with an authority.',
     )
     crs: Optional[CrsModel] = None

--- a/pydggsapi/schemas/ogc_dggs/dggrs_list.py
+++ b/pydggsapi/schemas/ogc_dggs/dggrs_list.py
@@ -17,8 +17,8 @@ class DggrsItem(BaseModel):
         ...,
         description='Title of this Discrete Global Grid System, normally used for display to a human',
     )
-    uri: Optional[AnyUrl] = Field(
-        None,
+    uri: Union[AnyUrl, str] = Field(
+        ...,
         description='Identifier for this Discrete Global Grid Reference System registered with an authority.',
     )
     links: List[Link] = Field(
@@ -28,5 +28,5 @@ class DggrsItem(BaseModel):
 
 
 class DggrsListResponse(BaseModel):
-    links: List[Link]
     dggrs: List[DggrsItem]
+    links: List[Link]


### PR DESCRIPTION
- provide link media-type when available
- add `dggs-zone-info` template-uri link
- ensure DGGRS `uri` parameter is indicated (auto-resolve expected OGC Registry entry otherwise)
- ensure DGGRS listing (global or per-collection) forward all metadata required by `DggrsItem`
- ensure the `dggrs`/`links` order are consistent between responses
- hide `type`, `varBase`, etc. parameters from links when not provided