### PR TITLE
ZarrCollectionProvider:

### DIFF
--- a/pydggsapi/dependencies/collections_providers/zarr_collection_provider.py
+++ b/pydggsapi/dependencies/collections_providers/zarr_collection_provider.py
@@ -107,14 +107,7 @@ class ZarrCollectionProvider(AbstractCollectionProvider):
             else:
                 cols = OrderedSet(ds.data_vars) if ("*" in datasource.data_cols) else OrderedSet(datasource.data_cols)
                 cols = list(cols - OrderedSet(datasource.exclude_data_cols))
-                #idx_mask = ds[id_col].isin(np.array(zoneIds, dtype=ds[id_col].dtype))
-                #zarr_result = ds.sel({id_col: idx_mask})
-                # zarr_result = ds.sel({id_col: np.array(zoneIds, dtype=ds[id_col].dtype)}, method="nearest", tolerance=0.5)
-                #zarr_result = zarr_result.drop_duplicates(id_col, keep='first')
-                ctx = xql.XarrayContext()
-                ctx.from_dataset('ds', ds)
-                sql = f"""select * from ds where ("{id_col}" in ({', '.join(f"'{z}'" for z in zoneIds)}))"""
-                zarr_result = xr.Dataset.from_dataframe(ctx.sql(sql).to_pandas().set_index(id_col))
+                zarr_result = ds.query({id_col: f'{id_col} in {zoneIds}'})
                 zarr_result = zarr_result[cols]
         except Exception as e:
             # Zarr will raise exception if nothing matched


### PR DESCRIPTION
- changed back to use the query function of an xarray dataset to select data by zoneIds.
- xarray-sql is faster, but for a large dataset (> 60 million rows), it ingests the dataset into memory, which causes a memory issue.
- The handling of CQL2 filter remains unchanged (keep using xarray-sql), but we need to find a better way to deal with large datasets.